### PR TITLE
fix: fix hide footer bug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -235,7 +235,7 @@ async function run(): Promise<void> {
       newTopFeatures,
       newTopPRs,
       DASHBOARD_HEADER,
-      HIDE_DASHBOARD_FOOTER ? DASHBOARD_FOOTER : ''
+      !HIDE_DASHBOARD_FOOTER ? DASHBOARD_FOOTER : ''
     )
     DRY_RUN
       ? info(`Dashboard body: ${dashboard_body}.`)


### PR DESCRIPTION
This PR fixes a small bug which caused the `HIDE_DASCHBOARD_FOOTER` to work incorrectly.